### PR TITLE
IpAssignDemandCreateSequence 에 명시된 보상트랜젝션 구현

### DIFF
--- a/src/main/kotlin/site/iplease/iadserver/domain/demand/data/dto/IpAssignDemandErrorOnStatusDto.kt
+++ b/src/main/kotlin/site/iplease/iadserver/domain/demand/data/dto/IpAssignDemandErrorOnStatusDto.kt
@@ -3,5 +3,6 @@ package site.iplease.iadserver.domain.demand.data.dto
 //IpAssignDemandCreate SequenceDiagram 참조
 data class IpAssignDemandErrorOnStatusDto (
     val demandId: Long,
+    val issuerId: Long,
     val message: String
 )

--- a/src/main/kotlin/site/iplease/iadserver/domain/demand/data/dto/IpAssignDemandErrorOnStatusDto.kt
+++ b/src/main/kotlin/site/iplease/iadserver/domain/demand/data/dto/IpAssignDemandErrorOnStatusDto.kt
@@ -1,0 +1,7 @@
+package site.iplease.iadserver.domain.demand.data.dto
+
+//IpAssignDemandCreate SequenceDiagram 참조
+data class IpAssignDemandErrorOnStatusDto (
+    val demandId: Long,
+    val message: String
+)

--- a/src/main/kotlin/site/iplease/iadserver/domain/demand/service/DemandErrorService.kt
+++ b/src/main/kotlin/site/iplease/iadserver/domain/demand/service/DemandErrorService.kt
@@ -1,0 +1,8 @@
+package site.iplease.iadserver.domain.demand.service
+
+import reactor.core.publisher.Mono
+import site.iplease.iadserver.domain.demand.data.dto.IpAssignDemandErrorOnStatusDto
+
+interface DemandErrorService {
+    fun errorOnStatus(demand: IpAssignDemandErrorOnStatusDto): Mono<Unit>
+}

--- a/src/main/kotlin/site/iplease/iadserver/domain/demand/service/DemandErrorServiceImpl.kt
+++ b/src/main/kotlin/site/iplease/iadserver/domain/demand/service/DemandErrorServiceImpl.kt
@@ -1,0 +1,33 @@
+package site.iplease.iadserver.domain.demand.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.toMono
+import site.iplease.iadserver.domain.demand.data.dto.IpAssignDemandErrorOnStatusDto
+import site.iplease.iadserver.infra.alarm.service.PushAlarmService
+import kotlin.random.Random
+import kotlin.random.nextUInt
+
+@Service
+class DemandErrorServiceImpl(
+    private val pushAlarmService: PushAlarmService
+): DemandErrorService {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    override fun errorOnStatus(demand: IpAssignDemandErrorOnStatusDto): Mono<Unit> =
+        Unit.toMono()
+            .map { createRandomId() }
+            .flatMap { id -> logErrorOnStatus(id, demand) }
+            .flatMap { id -> pushAlarmService.publish("할당IP신청중, 오류가 발생했습니다!", "다음 아이디로 관리자에게 문의해주세요!  - $id") }
+
+    private fun logErrorOnStatus(id: String, demand: IpAssignDemandErrorOnStatusDto): Mono<String> =
+        id.toMono()
+            .map {
+                logger.warn("[$id] 할당IP신청중 오류가 발생했습니다")
+                logger.warn("[$id] demandId: ${demand.demandId}")
+                logger.warn("[$id] message: ${demand.message}")
+            }.map { id }
+
+    //가끔 한두번은 겹쳐도 상관없다.
+    private fun createRandomId() = Random.nextUInt().toString()
+}

--- a/src/main/kotlin/site/iplease/iadserver/domain/demand/service/DemandErrorServiceImpl.kt
+++ b/src/main/kotlin/site/iplease/iadserver/domain/demand/service/DemandErrorServiceImpl.kt
@@ -18,12 +18,13 @@ class DemandErrorServiceImpl(
         Unit.toMono()
             .map { createRandomId() }
             .flatMap { id -> logErrorOnStatus(id, demand) }
-            .flatMap { id -> pushAlarmService.publish("할당IP신청중, 오류가 발생했습니다!", "다음 아이디로 관리자에게 문의해주세요!  - $id") }
+            .flatMap { id -> pushAlarmService.publish(demand.issuerId, "할당IP신청중, 오류가 발생했습니다!", "다음 아이디로 관리자에게 문의해주세요!  - $id") }
 
     private fun logErrorOnStatus(id: String, demand: IpAssignDemandErrorOnStatusDto): Mono<String> =
         id.toMono()
             .map {
                 logger.warn("[$id] 할당IP신청중 오류가 발생했습니다")
+                logger.warn("[$id] issuerId: ${demand.issuerId}")
                 logger.warn("[$id] demandId: ${demand.demandId}")
                 logger.warn("[$id] message: ${demand.message}")
             }.map { id }

--- a/src/main/kotlin/site/iplease/iadserver/domain/demand/subscriber/IpAssignDemandErrorOnStatusSubscriberV1.kt
+++ b/src/main/kotlin/site/iplease/iadserver/domain/demand/subscriber/IpAssignDemandErrorOnStatusSubscriberV1.kt
@@ -1,0 +1,21 @@
+package site.iplease.iadserver.domain.demand.subscriber
+
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+import site.iplease.iadserver.domain.demand.service.DemandErrorService
+import site.iplease.iadserver.domain.demand.util.DemandErrorOnStatusConverter
+import site.iplease.iadserver.global.demand.message.IpAssignDemandErrorOnStatusMessage
+import site.iplease.iadserver.global.demand.subscriber.IpAssignDemandErrorOnStatusSubscriber
+
+@Component
+class IpAssignDemandErrorOnStatusSubscriberV1(
+    private val demandErrorOnStatusConverter: DemandErrorOnStatusConverter,
+    private val demandErrorService: DemandErrorService
+): IpAssignDemandErrorOnStatusSubscriber {
+    override fun subscribe(message: IpAssignDemandErrorOnStatusMessage) {
+        demandErrorOnStatusConverter.convert(message)
+            .flatMap { demand -> demandErrorService.errorOnStatus(demand) }
+            .onErrorResume { Mono.empty() }
+            .block()
+    }
+}

--- a/src/main/kotlin/site/iplease/iadserver/domain/demand/util/DemandErrorOnStatusConverter.kt
+++ b/src/main/kotlin/site/iplease/iadserver/domain/demand/util/DemandErrorOnStatusConverter.kt
@@ -1,0 +1,9 @@
+package site.iplease.iadserver.domain.demand.util
+
+import reactor.core.publisher.Mono
+import site.iplease.iadserver.domain.demand.data.dto.IpAssignDemandErrorOnStatusDto
+import site.iplease.iadserver.global.demand.message.IpAssignDemandErrorOnStatusMessage
+
+interface DemandErrorOnStatusConverter {
+    fun convert(message: IpAssignDemandErrorOnStatusMessage): Mono<IpAssignDemandErrorOnStatusDto>
+}

--- a/src/main/kotlin/site/iplease/iadserver/domain/demand/util/DemandErrorOnStatusConverterImpl.kt
+++ b/src/main/kotlin/site/iplease/iadserver/domain/demand/util/DemandErrorOnStatusConverterImpl.kt
@@ -1,0 +1,17 @@
+package site.iplease.iadserver.domain.demand.util
+
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.toMono
+import site.iplease.iadserver.domain.demand.data.dto.IpAssignDemandErrorOnStatusDto
+import site.iplease.iadserver.global.demand.message.IpAssignDemandErrorOnStatusMessage
+
+@Component
+class DemandErrorOnStatusConverterImpl: DemandErrorOnStatusConverter {
+    override fun convert(message: IpAssignDemandErrorOnStatusMessage): Mono<IpAssignDemandErrorOnStatusDto> =
+        message.toMono()
+            .map { IpAssignDemandErrorOnStatusDto(
+                demandId = message.demandId,
+                message = message.message
+            ) }
+}

--- a/src/main/kotlin/site/iplease/iadserver/domain/demand/util/DemandErrorOnStatusConverterImpl.kt
+++ b/src/main/kotlin/site/iplease/iadserver/domain/demand/util/DemandErrorOnStatusConverterImpl.kt
@@ -12,6 +12,7 @@ class DemandErrorOnStatusConverterImpl: DemandErrorOnStatusConverter {
         message.toMono()
             .map { IpAssignDemandErrorOnStatusDto(
                 demandId = message.demandId,
+                issuerId = message.issuerId,
                 message = message.message
             ) }
 }

--- a/src/main/kotlin/site/iplease/iadserver/global/demand/message/IpAssignDemandErrorOnStatusMessage.kt
+++ b/src/main/kotlin/site/iplease/iadserver/global/demand/message/IpAssignDemandErrorOnStatusMessage.kt
@@ -1,0 +1,6 @@
+package site.iplease.iadserver.global.demand.message
+
+data class IpAssignDemandErrorOnStatusMessage(
+    val demandId: Long,
+    val message: String
+)

--- a/src/main/kotlin/site/iplease/iadserver/global/demand/message/IpAssignDemandErrorOnStatusMessage.kt
+++ b/src/main/kotlin/site/iplease/iadserver/global/demand/message/IpAssignDemandErrorOnStatusMessage.kt
@@ -2,5 +2,6 @@ package site.iplease.iadserver.global.demand.message
 
 data class IpAssignDemandErrorOnStatusMessage(
     val demandId: Long,
+    val issuerId: Long,
     val message: String
 )

--- a/src/main/kotlin/site/iplease/iadserver/global/demand/subscriber/IpAssignDemandErrorOnStatusSubscriber.kt
+++ b/src/main/kotlin/site/iplease/iadserver/global/demand/subscriber/IpAssignDemandErrorOnStatusSubscriber.kt
@@ -1,0 +1,7 @@
+package site.iplease.iadserver.global.demand.subscriber
+
+import site.iplease.iadserver.global.demand.message.IpAssignDemandErrorOnStatusMessage
+
+interface IpAssignDemandErrorOnStatusSubscriber {
+    fun subscribe(message: IpAssignDemandErrorOnStatusMessage)
+}

--- a/src/main/kotlin/site/iplease/iadserver/infra/alarm/service/DummyPushAlarmService.kt
+++ b/src/main/kotlin/site/iplease/iadserver/infra/alarm/service/DummyPushAlarmService.kt
@@ -9,10 +9,11 @@ import reactor.kotlin.core.publisher.toMono
 class DummyPushAlarmService: PushAlarmService {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    override fun publish(title: String, description: String): Mono<Unit> = Unit.toMono().map { sendAlarm(title, description) }
+    override fun publish(receiverId: Long, title: String, description: String): Mono<Unit> = Unit.toMono().map { sendAlarm(receiverId, title, description) }
 
-    private fun sendAlarm(title: String, description: String) {
+    private fun sendAlarm(receiverId: Long, title: String, description: String) {
         logger.info("푸쉬알람을 보냅니다.")
+        logger.info("receiver: $receiverId")
         logger.info("title: $title")
         logger.info("description: $description")
     }

--- a/src/main/kotlin/site/iplease/iadserver/infra/alarm/service/PushAlarmService.kt
+++ b/src/main/kotlin/site/iplease/iadserver/infra/alarm/service/PushAlarmService.kt
@@ -3,5 +3,5 @@ package site.iplease.iadserver.infra.alarm.service
 import reactor.core.publisher.Mono
 
 interface PushAlarmService {
-    fun publish(title: String, description: String): Mono<Unit>
+    fun publish(receiverId: Long, title: String, description: String): Mono<Unit>
 }

--- a/src/main/kotlin/site/iplease/iadserver/infra/message/listener/RabbitMqListener.kt
+++ b/src/main/kotlin/site/iplease/iadserver/infra/message/listener/RabbitMqListener.kt
@@ -26,8 +26,12 @@ class RabbitMqListener(
                 objectMapper.toMono()
                     .map { it.readValue(String(message.body), IpAssignDemandErrorOnStatusMessage::class.java) }
                     .map { ipAssignDemandErrorOnStatusSubscriber.subscribe(message = it) }
-                    .doOnError{ throwable -> logger.error("메세지를 직렬화하는도중 오류가 발생하였습니다!") }
-                    .onErrorResume { Mono.empty() }
+                    .doOnError{ throwable ->
+                        logger.error("메세지를 직렬화하는도중 오류가 발생하였습니다!")
+                        logger.error("exception: ${throwable.localizedMessage}")
+                        logger.error("payload(string): ${String(message.body)}")
+                        logger.error("payload(byte): ${message.body}")
+                    }.onErrorResume { Mono.empty() }
                     .block()
             else -> {
                 logger.warn("처리대상이 아닌 메세지가 바인딩되어있습니다!")

--- a/src/main/kotlin/site/iplease/iadserver/infra/message/listener/RabbitMqListener.kt
+++ b/src/main/kotlin/site/iplease/iadserver/infra/message/listener/RabbitMqListener.kt
@@ -1,0 +1,40 @@
+package site.iplease.iadserver.infra.message.listener
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.amqp.core.Message
+import org.springframework.amqp.rabbit.annotation.RabbitListener
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.toMono
+import site.iplease.iadserver.global.demand.message.IpAssignDemandErrorOnStatusMessage
+import site.iplease.iadserver.global.demand.subscriber.IpAssignDemandErrorOnStatusSubscriber
+import site.iplease.iadserver.infra.message.type.MessageType
+
+@Component
+class RabbitMqListener(
+    private val ipAssignDemandErrorOnStatusSubscriber: IpAssignDemandErrorOnStatusSubscriber,
+    private val objectMapper: ObjectMapper
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    @RabbitListener(queues = ["iplease.ip.assign.demand"])
+    fun listen(message: Message) {
+        val routingKey = message.messageProperties.receivedRoutingKey
+        when(MessageType.of(routingKey)) {
+            MessageType.IP_ASSIGN_DEMAND_ERROR_ON_STATUS ->
+                objectMapper.toMono()
+                    .map { it.readValue(String(message.body), IpAssignDemandErrorOnStatusMessage::class.java) }
+                    .map { ipAssignDemandErrorOnStatusSubscriber.subscribe(message = it) }
+                    .doOnError{ throwable -> logger.error("메세지를 직렬화하는도중 오류가 발생하였습니다!") }
+                    .onErrorResume { Mono.empty() }
+                    .block()
+            else -> {
+                logger.warn("처리대상이 아닌 메세지가 바인딩되어있습니다!")
+                logger.warn("routingKey: ${message.messageProperties.receivedRoutingKey}")
+                logger.warn("payload(string): ${String(message.body)}")
+                logger.warn("payload(byte): ${message.body}")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/site/iplease/iadserver/infra/message/type/MessageType.kt
+++ b/src/main/kotlin/site/iplease/iadserver/infra/message/type/MessageType.kt
@@ -3,5 +3,13 @@ package site.iplease.iadserver.infra.message.type
 enum class MessageType(
     val routingKey: String
 ) {
-    IP_ASSIGN_DEMAND_CREATE("ipAssignDemandCreate")
+    IP_ASSIGN_DEMAND_CREATE("ipAssignDemandCreate"),
+    IP_ASSIGN_DEMAND_ERROR_ON_STATUS("ipAssignDemandErrorOnStatus"),
+    UNKNOWN("");
+
+    companion object {
+        fun of(routingKey: String) =
+            kotlin.runCatching { values().first { it.routingKey == routingKey } }
+                .getOrElse { UNKNOWN }
+    }
 }


### PR DESCRIPTION
#2 에서 누락된, 보상트랜젝션 관련 기능을 추가구현하였습니다. 
ipAssignDemandErrorOnStatus 메세지 수신시 다음과 같은 로직을 수행합니다.
- 푸시알림서비스에게 오류알림 송신요청
- 발생한 오류정보 로깅